### PR TITLE
헤로쿠에 배포하기 - DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,6 +38,7 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
조사해본 결과, cleardb의 기본 mysql 버전이 `5.6`으로  (`article_comment_content` 인덱스 사이즈가 너무 큼)
너무 낮기 때문에 대안으로 jawsDB로 변경
기본 mysql 버전 `8.0`
이를 이용해 환경변수를 다시 잡음

This fixes #41 

* https://devcenter.heroku.com/articles/jawsdb#provisioning-with-custom-options
* https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup